### PR TITLE
Mm/recipe list display

### DIFF
--- a/src/main/java/pl/coderslab/dao/RecipeDao.java
+++ b/src/main/java/pl/coderslab/dao/RecipeDao.java
@@ -1,21 +1,15 @@
 package pl.coderslab.dao;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import pl.coderslab.exception.NotFoundException;
 import pl.coderslab.model.Recipe;
 import pl.coderslab.utils.DbUtil;
+
+import java.sql.*;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 public class RecipeDao {
 
@@ -27,7 +21,7 @@ public class RecipeDao {
   private static final String UPDATE_RECIPE_QUERY = "UPDATE recipe SET name = ?, ingredients = ?, description = ?, updated = ?, preparation_time = ?, preparation = ?, admin_id = ? where id = ?;";
 
   private static final String COUNT_RECIPE_QUERY = "SELECT COUNT(*) AS recipe_count FROM recipe WHERE admin_id = ?";
-
+  private static final String FIND_ALL_RECIPES_FOR_ADMIN = "SELECT recipe.id as id, recipe.name as name, recipe.description as description FROM recipe JOIN admins ON recipe.admin_id = admins.id WHERE admins.id = ? ORDER BY recipe.created DESC;";
   /**
    * Create recipe
    *
@@ -204,6 +198,29 @@ public class RecipeDao {
       e.printStackTrace();
     }
     return count;
+  }
+
+  /**
+   *
+   * @param adminId: int value which is primary key in admins table in scrumlab database.
+   * @return List of Recipe objects with populated id, name and description fields
+   */
+  public List<Recipe> getRecipesForAdmin(int adminId) {
+    List<Recipe> recipes = new ArrayList<>();
+    try (Connection connection = DbUtil.getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(FIND_ALL_RECIPES_FOR_ADMIN)) {
+      preparedStatement.setInt(1, adminId);
+      ResultSet resultSet = preparedStatement.executeQuery();
+      while (resultSet.next()) {
+        Recipe recipe = new Recipe();
+        recipe.setId(resultSet.getInt("id"));
+        recipe.setName(resultSet.getString("name"));
+        recipe.setDescription(resultSet.getString("description"));
+        recipes.add(recipe);
+      }
+    } catch (SQLException e) {
+      e.printStackTrace();
+    }
+    return recipes;
   }
 }
 

--- a/src/main/java/pl/coderslab/dao/RecipeDao.java
+++ b/src/main/java/pl/coderslab/dao/RecipeDao.java
@@ -21,7 +21,7 @@ public class RecipeDao {
   private static final String UPDATE_RECIPE_QUERY = "UPDATE recipe SET name = ?, ingredients = ?, description = ?, updated = ?, preparation_time = ?, preparation = ?, admin_id = ? where id = ?;";
 
   private static final String COUNT_RECIPE_QUERY = "SELECT COUNT(*) AS recipe_count FROM recipe WHERE admin_id = ?";
-  private static final String FIND_ALL_RECIPES_FOR_ADMIN_QUERY = "SELECT recipe.id as id, recipe.name as name, recipe.description as description FROM recipe JOIN admins ON recipe.admin_id = admins.id WHERE admins.id = ? ORDER BY recipe.id;";
+  private static final String FIND_ALL_RECIPES_FOR_ADMIN_QUERY = "SELECT recipe.id as id, recipe.name as name, recipe.description as description FROM recipe JOIN admins ON recipe.admin_id = admins.id WHERE admins.id = ? ORDER BY recipe.id DESC";
   /**
    * Create recipe
    *

--- a/src/main/java/pl/coderslab/dao/RecipeDao.java
+++ b/src/main/java/pl/coderslab/dao/RecipeDao.java
@@ -21,7 +21,7 @@ public class RecipeDao {
   private static final String UPDATE_RECIPE_QUERY = "UPDATE recipe SET name = ?, ingredients = ?, description = ?, updated = ?, preparation_time = ?, preparation = ?, admin_id = ? where id = ?;";
 
   private static final String COUNT_RECIPE_QUERY = "SELECT COUNT(*) AS recipe_count FROM recipe WHERE admin_id = ?";
-  private static final String FIND_ALL_RECIPES_FOR_ADMIN = "SELECT recipe.id as id, recipe.name as name, recipe.description as description FROM recipe JOIN admins ON recipe.admin_id = admins.id WHERE admins.id = ? ORDER BY recipe.created DESC;";
+  private static final String FIND_ALL_RECIPES_FOR_ADMIN_QUERY = "SELECT recipe.id as id, recipe.name as name, recipe.description as description FROM recipe JOIN admins ON recipe.admin_id = admins.id WHERE admins.id = ? ORDER BY recipe.id;";
   /**
    * Create recipe
    *
@@ -207,7 +207,7 @@ public class RecipeDao {
    */
   public List<Recipe> getRecipesForAdmin(int adminId) {
     List<Recipe> recipes = new ArrayList<>();
-    try (Connection connection = DbUtil.getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(FIND_ALL_RECIPES_FOR_ADMIN)) {
+    try (Connection connection = DbUtil.getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(FIND_ALL_RECIPES_FOR_ADMIN_QUERY)) {
       preparedStatement.setInt(1, adminId);
       ResultSet resultSet = preparedStatement.executeQuery();
       while (resultSet.next()) {

--- a/src/main/java/pl/coderslab/web/AddNewRecipe.java
+++ b/src/main/java/pl/coderslab/web/AddNewRecipe.java
@@ -2,7 +2,6 @@ package pl.coderslab.web;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import pl.coderslab.dao.AdminDao;
 import pl.coderslab.dao.RecipeDao;
 import pl.coderslab.model.Recipe;
 
@@ -17,14 +16,10 @@ import java.io.IOException;
 @WebServlet("/app/recipe/add")
 public class AddNewRecipe extends HttpServlet {
     RecipeDao recipeDao = new RecipeDao();
-    AdminDao adminDao = new AdminDao();
     public static final Logger logger = LogManager.getLogger(IsLoggedInFilter.class);
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        HttpSession session = req.getSession();
-        int adminId = (int) session.getAttribute("adminId");
 
-        req.setAttribute("adminName", adminDao.read(adminId).getFirstName());
         getServletContext().getRequestDispatcher("/addNewRecipe.jsp").forward(req, resp);
     }
 

--- a/src/main/java/pl/coderslab/web/AdminRecipeList.java
+++ b/src/main/java/pl/coderslab/web/AdminRecipeList.java
@@ -1,0 +1,33 @@
+package pl.coderslab.web;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import pl.coderslab.dao.RecipeDao;
+import pl.coderslab.model.Recipe;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.List;
+
+
+@WebServlet("/app/recipe/list")
+public class AdminRecipeList extends HttpServlet {
+    public static final RecipeDao recipeDao = new RecipeDao();
+    public static final Logger logger = LogManager.getLogger(AdminRecipeList.class);
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        HttpSession session = req.getSession();
+
+        int adminId = (int) session.getAttribute("adminId");
+
+        List<Recipe> recipes = recipeDao.getRecipesForAdmin(adminId);
+        session.setAttribute("userRecipes", recipes);
+
+        getServletContext().getRequestDispatcher("/user-recipes.jsp");
+    }
+}

--- a/src/main/java/pl/coderslab/web/AdminRecipeList.java
+++ b/src/main/java/pl/coderslab/web/AdminRecipeList.java
@@ -26,8 +26,9 @@ public class AdminRecipeList extends HttpServlet {
         int adminId = (int) session.getAttribute("adminId");
 
         List<Recipe> recipes = recipeDao.getRecipesForAdmin(adminId);
+        recipes.forEach(logger::info);
         session.setAttribute("userRecipes", recipes);
 
-        getServletContext().getRequestDispatcher("/user-recipes.jsp");
+        getServletContext().getRequestDispatcher("/admin-recipe-list.jsp").forward(req, resp);
     }
 }

--- a/src/main/java/pl/coderslab/web/Dashboard.java
+++ b/src/main/java/pl/coderslab/web/Dashboard.java
@@ -2,10 +2,8 @@ package pl.coderslab.web;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import pl.coderslab.dao.AdminDao;
 import pl.coderslab.dao.PlanDao;
 import pl.coderslab.dao.RecipeDao;
-import pl.coderslab.model.LastAddedPlanDto;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -14,14 +12,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.io.IOException;
-import java.util.List;
 
 @WebServlet("/app/dashboard")
 public class Dashboard extends HttpServlet {
 
     RecipeDao recipeDao = new RecipeDao();
     PlanDao planDao = new PlanDao();
-    AdminDao adminDao = new AdminDao();
     public static final Logger logger = LogManager.getLogger(IsLoggedInFilter.class);
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
@@ -31,7 +27,6 @@ public class Dashboard extends HttpServlet {
         try {
             int adminId = (int) session.getAttribute("adminId");
 
-            req.setAttribute("adminName", adminDao.read(adminId).getFirstName());
             req.setAttribute("recipeCount", recipeDao.countRecipesByAdminId(adminId));
             req.setAttribute("planCount", planDao.getPlanCountByAdminId(adminId));
             req.setAttribute("mealList", planDao.getLastAddedPlan(adminId));

--- a/src/main/java/pl/coderslab/web/HomeServlet.java
+++ b/src/main/java/pl/coderslab/web/HomeServlet.java
@@ -1,6 +1,7 @@
 package pl.coderslab.web;
 
-import lombok.extern.java.Log;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -13,9 +14,9 @@ import java.io.IOException;
  * Do not change servlet address !!!
  */
 @WebServlet("")
-@Log
 public class HomeServlet extends HttpServlet {
-  
+
+  public static Logger log = LogManager.getLogger(HomeServlet.class);
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
       throws ServletException, IOException {

--- a/src/main/java/pl/coderslab/web/HomeServlet.java
+++ b/src/main/java/pl/coderslab/web/HomeServlet.java
@@ -1,17 +1,13 @@
 package pl.coderslab.web;
 
 import lombok.extern.java.Log;
-import pl.coderslab.dao.AdminDao;
-import pl.coderslab.dao.BookDao;
-import pl.coderslab.model.Admin;
-import pl.coderslab.model.Book;
+
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Do not change servlet address !!!

--- a/src/main/java/pl/coderslab/web/Login.java
+++ b/src/main/java/pl/coderslab/web/Login.java
@@ -1,6 +1,7 @@
 package pl.coderslab.web;
 
-import lombok.extern.java.Log;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import pl.coderslab.dao.AdminDao;
 import pl.coderslab.exception.UnauthorizedAdminException;
 import pl.coderslab.model.Admin;
@@ -14,10 +15,10 @@ import javax.servlet.http.HttpSession;
 import java.io.IOException;
 
 
-@Log
+
 @WebServlet("/login")
 public class Login extends HttpServlet {
-
+  public static final Logger log = LogManager.getLogger(Login.class);
   public static final AdminDao adminDao = new AdminDao();
 
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
@@ -39,8 +40,8 @@ public class Login extends HttpServlet {
       loginSession.setAttribute("adminId", authenticatedAdmin.getId());
       loginSession.setAttribute("adminName", authenticatedAdmin.getFirstName());
 
-      log.info("Session Id: " + loginSession.getId());
-      log.info("UserId: " + loginSession.getAttribute("adminId"));
+        log.info("Session Id: {}", loginSession.getId());
+        log.info("UserId: {}", loginSession.getAttribute("adminId"));
 
       resp.sendRedirect("/app/dashboard");
 

--- a/src/main/java/pl/coderslab/web/Login.java
+++ b/src/main/java/pl/coderslab/web/Login.java
@@ -1,15 +1,17 @@
-package pl.coderslab.model;
+package pl.coderslab.web;
 
-import java.io.IOException;
+import lombok.extern.java.Log;
+import pl.coderslab.dao.AdminDao;
+import pl.coderslab.exception.UnauthorizedAdminException;
+import pl.coderslab.model.Admin;
+
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import lombok.extern.java.Log;
-import pl.coderslab.dao.AdminDao;
-import pl.coderslab.exception.UnauthorizedAdminException;
+import java.io.IOException;
 
 
 @Log
@@ -35,6 +37,7 @@ public class Login extends HttpServlet {
 
       HttpSession loginSession = req.getSession();
       loginSession.setAttribute("adminId", authenticatedAdmin.getId());
+      loginSession.setAttribute("adminName", authenticatedAdmin.getFirstName());
 
       log.info("Session Id: " + loginSession.getId());
       log.info("UserId: " + loginSession.getAttribute("adminId"));

--- a/src/main/webapp/admin-recipe-list.jsp
+++ b/src/main/webapp/admin-recipe-list.jsp
@@ -1,0 +1,48 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<!DOCTYPE html>
+<%@include file="viewCommonParts/appHeader.jsp" %>
+
+<section class="dashboard-section">
+    <div class="row dashboard-nowrap">
+        <%@include file="viewCommonParts/appSideMenu.jsp" %>
+
+        <div class="m-4 p-3 width-medium">
+            <div class="dashboard-content border-dashed p-3 m-4 view-height">
+                <div class="row border-bottom border-3 p-1 m-1">
+                    <div class="col noPadding"><h3 class="color-header text-uppercase">Lista Przepisów</h3></div>
+                    <div class="col noPadding d-flex justify-content-end mb-2"><a href="${pageContext.request.contextPath}/app/recipe/add" class="btn btn-success rounded-0 pt-0 pb-0 pr-4 pl-4">Dodaj przepis</a></div>
+                </div>
+                <table class="table border-bottom schedules-content">
+                    <thead>
+                    <tr class="d-flex text-color-darker">
+                        <th scope="col" class="col-1">ID</th>
+                        <th scope="col" class="col-2">NAZWA</th>
+                        <th scope="col" class="col-7">OPIS</th>
+                        <th scope="col" class="col-2 center">AKCJE</th>
+                    </tr>
+                    </thead>
+                    <tbody class="text-color-lighter">
+                    <c:forEach var="recipe" items="${userRecipes}">
+                        <tr class="d-flex">
+                            <th scope="row" class="col-1">${recipe.getId()}</th>
+                            <td class="col-2">
+                                ${recipe.getName()}
+                            </td>
+                            <td class="col-7">${recipe.getDescription()}</td>
+                            <td class="col-2 d-flex align-items-center justify-content-center flex-wrap">
+                                <a href="#" class="btn btn-danger rounded-0 text-light m-1">Usuń</a>
+                                <a href="#" class="btn btn-info rounded-0 text-light m-1">Szczegóły</a>
+                                <a href="#" class="btn btn-warning rounded-0 text-light m-1">Edytuj</a>
+                            </td>
+                        </tr>
+                    </c:forEach>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</section>
+<%@include file="viewCommonParts/appFooter.jsp" %>
+</body>
+</html>

--- a/src/main/webapp/admin-recipe-list.jsp
+++ b/src/main/webapp/admin-recipe-list.jsp
@@ -34,9 +34,9 @@
                             </td>
                             <td class="col-7">${recipe.getDescription()}</td>
                             <td class="col-2 d-flex align-items-center justify-content-center flex-wrap">
-                                <a href="#" class="btn btn-danger rounded-0 text-light m-1">Usuń</a>
-                                <a href="#" class="btn btn-info rounded-0 text-light m-1">Szczegóły</a>
-                                <a href="#" class="btn btn-warning rounded-0 text-light m-1">Edytuj</a>
+                                <a href="${pageContext.request.contextPath}/app/recipe/delete?id=${recipe.getId()}" class="btn btn-danger rounded-0 text-light m-1">Usuń</a>
+                                <a href="${pageContext.request.contextPath}/app/recipe/details?id=${recipe.getId()}" class="btn btn-info rounded-0 text-light m-1">Szczegóły</a>
+                                <a href="${pageContext.request.contextPath}/app/recipe/edit?id=${recipe.getId()}" class="btn btn-warning rounded-0 text-light m-1">Edytuj</a>
                             </td>
                         </tr>
                     </c:forEach>

--- a/src/main/webapp/admin-recipe-list.jsp
+++ b/src/main/webapp/admin-recipe-list.jsp
@@ -22,8 +22,8 @@
                         <th scope="col" class="col-2 center">AKCJE</th>
                     </tr>
                     </thead>
-                    <c:if test="${userRecipes.length() == 0}">
-                        <p>Nie masz jeszcze dodanych żadnych przepisóœ</p>
+                    <c:if test="${userRecipes.size() == 0}">
+                        <p>Nie masz jeszcze dodanych żadnych przepisów</p>
                     </c:if>
                     <tbody class="text-color-lighter">
                     <c:forEach var="recipe" items="${userRecipes}">

--- a/src/main/webapp/admin-recipe-list.jsp
+++ b/src/main/webapp/admin-recipe-list.jsp
@@ -22,6 +22,9 @@
                         <th scope="col" class="col-2 center">AKCJE</th>
                     </tr>
                     </thead>
+                    <c:if test="${userRecipes.length() == 0}">
+                        <p>Nie masz jeszcze dodanych żadnych przepisóœ</p>
+                    </c:if>
                     <tbody class="text-color-lighter">
                     <c:forEach var="recipe" items="${userRecipes}">
                         <tr class="d-flex">


### PR DESCRIPTION
Move Login servlet class into `web` directory so it is are together with other servlets.
Create AdminRecipeList servlet.
Create admin-recipe-list.jsp:

I refactored servlets because of derived common app view part: header.jsp - Header needs to have access to `adminName` session attribute right away after admin is authenticated - otherwise we have to retrieve `adminName` in every servlet that uses view that includes `header.jsp.` I set session attribute `adminName` in Login servlet after admin authenticated. This means that we already have `adminName` and `adminId` in session so we don't have to use `AdminDao.read` method to retrieve `adminName` in every servlet .
Therefore I made following changes:

- Change Login servlet:
   - Set `adminName` session attribute along with `adminId` attribute if the admin is authenticated.
- Change `AddNewRecipe` servlet:
   - Remove private static final `AdminDao` field.
   - Remove `getSession` method in `doGet` method
   - Remove `getAttribute("adminId")` statement in doGet method
    - Remove setting session attribute for `adminName` from `adminDao.read` method in `doGet` method.
- Change Dashboard servlet:
    - Remove private static final `AdminDao` field.
    - Remove setting `adminName` session attribute by calling `adminDao.read` method.

